### PR TITLE
Add Quark Compat and Fix Eyes being useable via Offhand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,11 +77,11 @@ dependencies {
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 
     // Quark (Contains Matrix Enchanting)
-    implementation fg.deobf("curse.maven:quark-243121:5418252")
+    compileOnly fg.deobf("curse.maven:quark-243121:5418252")
     // Zeta (dep of Quark)
-    implementation fg.deobf("curse.maven:zeta-968868:5418213")
+    compileOnly fg.deobf("curse.maven:zeta-968868:5418213")
     // Quark Oddities (Actually activates Matrix Enchanting)
-    implementation fg.deobf("curse.maven:oddities-301051:5070502")
+    compileOnly fg.deobf("curse.maven:oddities-301051:5070502")
 }
 
 mixin {

--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,25 @@ sourceSets.main.resources {
     srcDir 'src/generated/resources'
 }
 
+repositories {
+    maven {
+        url "https://cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
+}
+
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+
+    // Quark (Contains Matrix Enchanting)
+    implementation fg.deobf("curse.maven:quark-243121:5418252")
+    // Zeta (dep of Quark)
+    implementation fg.deobf("curse.maven:zeta-968868:5418213")
+    // Quark Oddities (Actually activates Matrix Enchanting)
+    implementation fg.deobf("curse.maven:oddities-301051:5070502")
 }
 
 mixin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ author=teamremastered
 release_type=R
 mod_version=5.2.3
 minecraft_version=1.20.1
-forge_version=47.0.19
+forge_version=47.1.3

--- a/src/main/java/com/teamremastered/endrem/events/ModEvents.java
+++ b/src/main/java/com/teamremastered/endrem/events/ModEvents.java
@@ -21,33 +21,6 @@ import org.jetbrains.annotations.Nullable;
 @SuppressWarnings("unused")
 @Mod.EventBusSubscriber
 public class ModEvents {
-
-
-    // Enable/Disable placing of vanilla Ender Eyes on end portal frame depending on configuration
-    @SubscribeEvent
-    public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (event.isCancelable() && !ERConfig.USE_ENDER_EYE.getRaw()) {
-            if (event.getEntity().getInventory().getSelected().getItem() instanceof EnderEyeItem) {
-                if (event.getLevel().getBlockState(event.getPos()).getBlock() == Blocks.END_PORTAL_FRAME) {
-                    event.setCanceled(true);
-                    event.getEntity().displayClientMessage(Component.translatable("block.endrem.ender_eye.use_warning"), true);
-                }
-            }
-        }
-    }
-
-    // Enable/Disable throwing of vanilla Ender Eyes depending on configuration
-    @SubscribeEvent
-    public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-        if (event.isCancelable() && !ERConfig.THROW_ENDER_EYE.getRaw()) {
-            if (event.getEntity().getInventory().getSelected().getItem() instanceof EnderEyeItem) {
-                event.setCanceled(true);
-                if (event.getLevel().getBlockState(event.getPos()).getBlock() != Blocks.END_PORTAL_FRAME)
-                    event.getEntity().displayClientMessage(Component.translatable("block.endrem.ender_eye.throw_warning"), true);
-            }
-        }
-    }
-
     @SubscribeEvent
     public static void onVillagerTradesEvent(VillagerTradesEvent event) {
         if (ERConfig.IS_EVIL_EYE_OBTAINABLE.getRaw() && event.getType() == VillagerProfession.CLERIC) {

--- a/src/main/java/com/teamremastered/endrem/mixin/EndRemasteredMixinPlugin.java
+++ b/src/main/java/com/teamremastered/endrem/mixin/EndRemasteredMixinPlugin.java
@@ -1,0 +1,52 @@
+package com.teamremastered.endrem.mixin;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraftforge.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class EndRemasteredMixinPlugin implements IMixinConfigPlugin {
+    private static final Map<String, Supplier<Boolean>> CONDITIONS = ImmutableMap.of(
+            "com.teamremastered.endrem.mixin.compat.MatrixEnchantingMenuMixin", () -> LoadingModList.get().getModFileById("quark") != null
+    );
+    @Override
+    public boolean shouldApplyMixin(String target, String mixinToApply) {
+        return CONDITIONS.getOrDefault(mixinToApply, () -> true).get();
+    }
+
+    @Override
+    public void onLoad(String s) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> set, Set<String> set1) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+}

--- a/src/main/java/com/teamremastered/endrem/mixin/EnderEyeItemMixin.java
+++ b/src/main/java/com/teamremastered/endrem/mixin/EnderEyeItemMixin.java
@@ -1,0 +1,39 @@
+package com.teamremastered.endrem.mixin;
+
+import com.teamremastered.endrem.config.ERConfig;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.EnderEyeItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EnderEyeItem.class)
+public class EnderEyeItemMixin {
+    @Inject(method = "useOn", at = @At("HEAD"), cancellable = true)
+    private void endrem$useOn(UseOnContext ctx, CallbackInfoReturnable<InteractionResult> cir){
+        if (!ERConfig.USE_ENDER_EYE.getRaw()){
+            Player player = ctx.getPlayer();
+            if (player != null) {
+                player.displayClientMessage(Component.translatable("block.endrem.ender_eye.use_warning"), true);
+            }
+            cir.setReturnValue(InteractionResult.PASS);
+        }
+    }
+
+    @Inject(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;startUsingItem(Lnet/minecraft/world/InteractionHand;)V", shift = At.Shift.BEFORE), cancellable = true)
+    private void endrem$use(Level level, Player player, InteractionHand hand, CallbackInfoReturnable<InteractionResultHolder<ItemStack>> cir){
+        if (!ERConfig.USE_ENDER_EYE.getRaw()){
+            player.displayClientMessage(Component.translatable("block.endrem.ender_eye.throw_warning"), true);
+            ItemStack item = player.getItemInHand(hand);
+            cir.setReturnValue(InteractionResultHolder.pass(item));
+        }
+    }
+}

--- a/src/main/java/com/teamremastered/endrem/mixin/EnderEyeItemMixin.java
+++ b/src/main/java/com/teamremastered/endrem/mixin/EnderEyeItemMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.world.item.EnderEyeItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -20,11 +21,13 @@ public class EnderEyeItemMixin {
     @Inject(method = "useOn", at = @At("HEAD"), cancellable = true)
     private void endrem$useOn(UseOnContext ctx, CallbackInfoReturnable<InteractionResult> cir){
         if (!ERConfig.USE_ENDER_EYE.getRaw()){
-            Player player = ctx.getPlayer();
-            if (player != null) {
-                player.displayClientMessage(Component.translatable("block.endrem.ender_eye.use_warning"), true);
+            if (ctx.getLevel().getBlockState(ctx.getClickedPos()).is(Blocks.END_PORTAL_FRAME)) {
+                Player player = ctx.getPlayer();
+                if (player != null) {
+                    player.displayClientMessage(Component.translatable("block.endrem.ender_eye.use_warning"), true);
+                }
+                cir.setReturnValue(InteractionResult.PASS);
             }
-            cir.setReturnValue(InteractionResult.PASS);
         }
     }
 

--- a/src/main/java/com/teamremastered/endrem/mixin/compat/MatrixEnchantingMenuMixin.java
+++ b/src/main/java/com/teamremastered/endrem/mixin/compat/MatrixEnchantingMenuMixin.java
@@ -1,24 +1,22 @@
-package com.teamremastered.endrem.mixin;
+package com.teamremastered.endrem.mixin.compat;
 
 import com.teamremastered.endrem.config.ERConfig;
 import com.teamremastered.endrem.registers.ERItems;
 import com.teamremastered.endrem.utils.CrypticEyeDistribution;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.EnchantmentMenu;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.violetmoon.quark.addons.oddities.inventory.MatrixEnchantingMenu;
 
 import java.util.Random;
 
-@SuppressWarnings("unused")
-@Mixin(EnchantmentMenu.class)
-public class PlayerEnchantMixin {
-
-    @Inject(method = "clickMenuButton", at = @At(value = "RETURN", ordinal = 2))
-    private void isEnchanting(final Player player, final int id, final CallbackInfoReturnable<Boolean> info) {
+@Mixin(MatrixEnchantingMenu.class)
+public class MatrixEnchantingMenuMixin {
+    @Inject(method = "finish", at = @At("TAIL"), remap = false)
+    private void endrem$finishEnchantingAtMatrixTable(Player player, ItemStack stack, CallbackInfo ci){
         CrypticEyeDistribution.rollForCrypticEye(player);
     }
 }

--- a/src/main/java/com/teamremastered/endrem/utils/CrypticEyeDistribution.java
+++ b/src/main/java/com/teamremastered/endrem/utils/CrypticEyeDistribution.java
@@ -10,7 +10,7 @@ import java.util.Random;
 public class CrypticEyeDistribution {
     public static void rollForCrypticEye(Player player){
         Random random = new Random();
-        int maxValue = 1;
+        int maxValue = 120;
         int randomNumber = random.nextInt(maxValue);
         if (ERConfig.IS_CRYPTIC_EYE_OBTAINABLE.getRaw() && !player.level().isClientSide && player != null) {
             if (randomNumber == maxValue - 1) {

--- a/src/main/java/com/teamremastered/endrem/utils/CrypticEyeDistribution.java
+++ b/src/main/java/com/teamremastered/endrem/utils/CrypticEyeDistribution.java
@@ -1,0 +1,21 @@
+package com.teamremastered.endrem.utils;
+
+import com.teamremastered.endrem.config.ERConfig;
+import com.teamremastered.endrem.registers.ERItems;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Random;
+
+public class CrypticEyeDistribution {
+    public static void rollForCrypticEye(Player player){
+        Random random = new Random();
+        int maxValue = 1;
+        int randomNumber = random.nextInt(maxValue);
+        if (ERConfig.IS_CRYPTIC_EYE_OBTAINABLE.getRaw() && !player.level().isClientSide && player != null) {
+            if (randomNumber == maxValue - 1) {
+                player.getInventory().add(new ItemStack(ERItems.CRYPTIC_EYE.get()));
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/endrem/lang/en_us.json
+++ b/src/main/resources/assets/endrem/lang/en_us.json
@@ -54,7 +54,7 @@
 
   "block.endrem.ender_eye.throw_warning": "This eye doesn't know where to go",
   "block.endrem.ender_eye.use_warning": "This eye doesn't want to be used",
-  "block.endrem.custom_eye.place": "This eye is can't be placed",
+  "block.endrem.custom_eye.place": "This eye can't be placed",
   "block.endrem.custom_eye.frame_has_eye": "This frame already has an eye",
   "block.endrem.custom_eye.broken": "This portal is not built properly",
 

--- a/src/main/resources/endrem.mixins.json
+++ b/src/main/resources/endrem.mixins.json
@@ -5,6 +5,7 @@
   "refmap": "endrem.refmap.json",
   "plugin": "com.teamremastered.endrem.mixin.EndRemasteredMixinPlugin",
   "mixins": [
+    "EnderEyeItemMixin",
     "PlayerEnchantMixin",
     "StrongholdPiecesMixin",
     "compat.MatrixEnchantingMenuMixin"

--- a/src/main/resources/endrem.mixins.json
+++ b/src/main/resources/endrem.mixins.json
@@ -3,9 +3,11 @@
   "package": "com.teamremastered.endrem.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "endrem.refmap.json",
+  "plugin": "com.teamremastered.endrem.mixin.EndRemasteredMixinPlugin",
   "mixins": [
     "PlayerEnchantMixin",
-    "StrongholdPiecesMixin"
+    "StrongholdPiecesMixin",
+    "compat.MatrixEnchantingMenuMixin"
   ],
   "minVersion": "0.8"
 }


### PR DESCRIPTION
### Issues Fixed
Fixes #74 
Adds Quark Compat for the Cryptic Eye; Quark Oddities (built-in into Quark but only activated when the separate Oddities jar is present) replaces the enchanting table with the Matrix Enchanter, making the cryptic eye unobtainable.
Fixes a typo in the en_us lang file.

### Implementation Details
Bump Forge version used in build to 47.1.3 (what Quark is built against)
Mixin into Quark's MatrixEnchantmentMenu; use existing code for determining if we should create an eye. Made into a utility to not duplicate the code.
Added a Mixin Plugin so we only apply this mixin when Quark is present
Mixin into EnderEyeItem to cancel usage there, instead of the events

### Testing
Tested with and without Quark (1.20.1), server and client
Tested without Quark (no version exists) for 1.20.2 and 1.20.4, client only